### PR TITLE
Refactor/struct word

### DIFF
--- a/wordlist/generator/csv.go
+++ b/wordlist/generator/csv.go
@@ -12,7 +12,7 @@ func GenerateCsvText(words []parse.Word) string {
 		builder.WriteString(",")
 		builder.WriteString(line.Name)
 		builder.WriteString(",")
-		builder.WriteString(line.Mean)
+		builder.WriteString(line.Meaning)
 		builder.WriteString("\n")
 	}
 	return builder.String()

--- a/wordlist/generator/csv_test.go
+++ b/wordlist/generator/csv_test.go
@@ -8,9 +8,9 @@ import (
 
 func TestParseHtmlOk(t *testing.T) {
 	data := []parse.Word{
-		{Position: "p10 10%", Name: "available", Mean: "使える"},
-		{Position: "p20 30%", Name: "currently", Mean: "現在は"},
-		{Position: "p30 50%", Name: "annual", Mean: "毎年恒例の"},
+		{Position: "p10 10%", Name: "available", Meaning: "使える"},
+		{Position: "p20 30%", Name: "currently", Meaning: "現在は"},
+		{Position: "p30 50%", Name: "annual", Meaning: "毎年恒例の"},
 	}
 
 	expected := `p10 10%, available, 使える

--- a/wordlist/generator/table.go
+++ b/wordlist/generator/table.go
@@ -88,7 +88,7 @@ func generateTableBody(words []parse.Word) string {
 		res += "<tr>"
 		res += "<td>" + word.Position + "</td>"
 		res += "<td>" + word.Name + "</td>"
-		res += "<td>" + word.Mean + "</td>"
+		res += "<td>" + word.Meaning + "</td>"
 		res += "</tr>"
 	}
 	res += "</table>"

--- a/wordlist/generator/table_test.go
+++ b/wordlist/generator/table_test.go
@@ -9,9 +9,9 @@ import (
 
 func TestParseCsvOk(t *testing.T) {
 	data := []parse.Word{
-		{Position: "p10 10%", Name: "available", Mean: "使える"},
-		{Position: "p20 30%", Name: "currently", Mean: "現在は"},
-		{Position: "p30 50%", Name: "annual", Mean: "毎年恒例の"},
+		{Position: "p10 10%", Name: "available", Meaning: "使える"},
+		{Position: "p20 30%", Name: "currently", Meaning: "現在は"},
+		{Position: "p30 50%", Name: "annual", Meaning: "毎年恒例の"},
 	}
 
 	expected := `<table>

--- a/wordlist/parse/parsecsv.go
+++ b/wordlist/parse/parsecsv.go
@@ -20,7 +20,7 @@ func ParseCsv(csv string) ([]Word, error) {
 		res[i] = Word{
 			Position: strings.TrimSpace(tmp[0]),
 			Name:     strings.TrimSpace(tmp[1]),
-			Mean:     strings.TrimSpace(tmp[2]),
+			Meaning:  strings.TrimSpace(tmp[2]),
 		}
 	}
 	return res, nil

--- a/wordlist/parse/parsecsv_test.go
+++ b/wordlist/parse/parsecsv_test.go
@@ -16,9 +16,9 @@ func TestParseCsvOk(t *testing.T) {
 		return
 	}
 	expected := []Word{
-		{Position: "p10 10%", Name: "available", Mean: "使える"},
-		{Position: "p20 30%", Name: "currently", Mean: "現在は"},
-		{Position: "p30 50%", Name: "annual", Mean: "毎年恒例の"},
+		{Position: "p10 10%", Name: "available", Meaning: "使える"},
+		{Position: "p20 30%", Name: "currently", Meaning: "現在は"},
+		{Position: "p30 50%", Name: "annual", Meaning: "毎年恒例の"},
 	}
 
 	isOk := true

--- a/wordlist/parse/parsehtml.go
+++ b/wordlist/parse/parsehtml.go
@@ -25,7 +25,7 @@ func ParseHtml(html string) ([]Word, error) {
 		info := Word{
 			Position: strings.TrimSpace(s.Find("td:nth-child(1)").Text()),
 			Name:     strings.TrimSpace(s.Find("td:nth-child(2)").Text()),
-			Mean:     strings.TrimSpace(s.Find("td:nth-child(3)").Text()),
+			Meaning:  strings.TrimSpace(s.Find("td:nth-child(3)").Text()),
 		}
 		res = append(res, info)
 	})

--- a/wordlist/parse/parsehtml_test.go
+++ b/wordlist/parse/parsehtml_test.go
@@ -101,9 +101,9 @@ func TestParseHtmlOk(t *testing.T) {
 		return
 	}
 	expected := []Word{
-		{Position: "p10 10%", Name: "available", Mean: "使える"},
-		{Position: "p20 30%", Name: "currently", Mean: "現在は"},
-		{Position: "p30 50%", Name: "annual", Mean: "毎年恒例の"},
+		{Position: "p10 10%", Name: "available", Meaning: "使える"},
+		{Position: "p20 30%", Name: "currently", Meaning: "現在は"},
+		{Position: "p30 50%", Name: "annual", Meaning: "毎年恒例の"},
 	}
 
 	isOk := true

--- a/wordlist/parse/word.go
+++ b/wordlist/parse/word.go
@@ -3,5 +3,5 @@ package parse
 type Word struct {
 	Name     string `json:"name"`
 	Position string `json:"position"`
-	Mean     string `json:"mean"`
+	Meaning  string `json:"meaning"`
 }


### PR DESCRIPTION
## 🔖 チケットへのリンク

- #11 

## ✨ やったこと

- Word構造体のMeanプロパティの名前をMeaningに変更した

## 🔥 やらないこと

- 無し

## 🙆 できるようになること（ユーザ目線）

- 無し

## 🙅 できなくなること（ユーザ目線）

- 無し

## 🚀 動作確認

- go testで全テストをパスすることを確認
- `wails build`が通ることを確認
- GUIでhtmlとcsvの両方向変換ができることを確認

## 👽️ その他

- 無し
