### PR TITLE
Feat/backend/filesaving

### DIFF
--- a/wordlist/app.go
+++ b/wordlist/app.go
@@ -45,10 +45,15 @@ func (a *App) GenerateCsv(html string) string {
 	return generator.GenerateCsvText(words)
 }
 
-func (a *App) Save(content string, ext string) {
-	file.Save(a.ctx, content, ext)
+func (a *App) Save(content string, ext string) string {
+	return file.Save(a.ctx, content, ext)
 }
 
-func (a *App) Open(ext string) string {
-	return file.Open(a.ctx, ext)
+func (a *App) SaveAs(content string, path string) {
+	file.SaveAs(a.ctx, content, path)
+}
+
+func (a *App) Open(ext string) []string {
+	content, filepath := file.Open(a.ctx, ext)
+	return []string{content, filepath}
 }

--- a/wordlist/app.go
+++ b/wordlist/app.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"wordlist/file"
 	"wordlist/generator"
 	"wordlist/parse"
 )
@@ -42,4 +43,12 @@ func (a *App) GenerateCsv(html string) string {
 		return err.Error()
 	}
 	return generator.GenerateCsvText(words)
+}
+
+func (a *App) Save(content string, ext string) {
+	file.Save(a.ctx, content, ext)
+}
+
+func (a *App) Open(ext string) string {
+	return file.Open(a.ctx, ext)
 }

--- a/wordlist/file/open.go
+++ b/wordlist/file/open.go
@@ -1,0 +1,46 @@
+package file
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/wailsapp/wails/v2/pkg/runtime"
+)
+
+func Open(ctx context.Context, ext string) string {
+	filter := []runtime.FileFilter{
+		{
+			DisplayName: ext + " files (*." + ext + ")",
+			Pattern:     "*." + ext,
+		},
+	}
+
+	dialogOptions := runtime.OpenDialogOptions{
+		DefaultDirectory:           "",
+		DefaultFilename:            "wordlist." + ext,
+		Title:                      "保存",
+		Filters:                    filter,
+		ShowHiddenFiles:            false,
+		CanCreateDirectories:       true,
+		ResolvesAliases:            true,
+		TreatPackagesAsDirectories: false,
+	}
+
+	selectedFiles, err := runtime.OpenMultipleFilesDialog(ctx, dialogOptions)
+	if len(selectedFiles) == 0 {
+		return ""
+	}
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+
+	selectedFile := selectedFiles[0]
+	bytes, err := os.ReadFile(selectedFile)
+	if err != nil {
+		panic(err)
+	}
+
+	return string(bytes)
+}

--- a/wordlist/file/open.go
+++ b/wordlist/file/open.go
@@ -8,7 +8,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
-func Open(ctx context.Context, ext string) string {
+func Open(ctx context.Context, ext string) (string, string) {
 	filter := []runtime.FileFilter{
 		{
 			DisplayName: ext + " files (*." + ext + ")",
@@ -29,11 +29,11 @@ func Open(ctx context.Context, ext string) string {
 
 	selectedFiles, err := runtime.OpenMultipleFilesDialog(ctx, dialogOptions)
 	if len(selectedFiles) == 0 {
-		return ""
+		return "", ""
 	}
 	if err != nil {
 		fmt.Println(err)
-		return ""
+		return "", ""
 	}
 
 	selectedFile := selectedFiles[0]
@@ -42,5 +42,5 @@ func Open(ctx context.Context, ext string) string {
 		panic(err)
 	}
 
-	return string(bytes)
+	return string(bytes), selectedFile
 }

--- a/wordlist/file/save.go
+++ b/wordlist/file/save.go
@@ -8,7 +8,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
-func Save(ctx context.Context, content string, ext string) {
+func Save(ctx context.Context, content string, ext string) string {
 	filter := []runtime.FileFilter{
 		{
 			DisplayName: ext + " files (*." + ext + ")",
@@ -28,11 +28,19 @@ func Save(ctx context.Context, content string, ext string) {
 
 	selectedFile, err := runtime.SaveFileDialog(ctx, dialogOptions)
 	if selectedFile == "" {
-		return
+		return ""
 	}
 	if err != nil {
 		fmt.Println(err)
-		return
+		return ""
 	}
 	os.WriteFile(selectedFile, []byte(content), 0644)
+	return selectedFile
+}
+
+func SaveAs(ctx context.Context, content string, path string) {
+	if path == "" {
+		return
+	}
+	os.WriteFile(path, []byte(content), 0644)
 }

--- a/wordlist/file/save.go
+++ b/wordlist/file/save.go
@@ -1,0 +1,38 @@
+package file
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/wailsapp/wails/v2/pkg/runtime"
+)
+
+func Save(ctx context.Context, content string, ext string) {
+	filter := []runtime.FileFilter{
+		{
+			DisplayName: ext + " files (*." + ext + ")",
+			Pattern:     "*." + ext,
+		},
+	}
+
+	dialogOptions := runtime.SaveDialogOptions{
+		DefaultDirectory:           "",
+		DefaultFilename:            "wordlist." + ext,
+		Title:                      "保存",
+		Filters:                    filter,
+		ShowHiddenFiles:            false,
+		CanCreateDirectories:       true,
+		TreatPackagesAsDirectories: false,
+	}
+
+	selectedFile, err := runtime.SaveFileDialog(ctx, dialogOptions)
+	if selectedFile == "" {
+		return
+	}
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	os.WriteFile(selectedFile, []byte(content), 0644)
+}

--- a/wordlist/frontend/src/App.tsx
+++ b/wordlist/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { GenerateTable, GenerateCsv } from "../wailsjs/go/main/App";
+import { GenerateTable, GenerateCsv, Save, Open } from "../wailsjs/go/main/App";
 import { Button, TextField } from "@mui/material";
 import styles from "./App.module.css";
 
@@ -14,6 +14,14 @@ function App() {
   const generateCsv = () => {
     GenerateCsv(htmlText).then((res) => setCsvText(res));
   };
+
+  const saveFile = (content: string, ext: string) => {
+    Save(content, ext);
+  }
+
+  const openFile = (ext: string, setState: (s: string) => void) => {
+    Open(ext).then((res) => setState(res));
+  }
 
   // ファイル読み込みボタン
   const FolderSelector = () => {
@@ -61,8 +69,21 @@ function App() {
       <div className={styles.titleArea}>
         <FolderSelector />
         <span style={{ color: "black" }}> filename: {fileName}</span>
-        <Button>csv保存</Button>
-        <Button>html保存</Button>
+
+        <Button onClick={() => {
+          saveFile(csvText, 'csv')
+        }}>csv保存</Button>
+        <Button onClick={() => {
+          saveFile(csvText, 'html')
+        }}>html保存</Button>
+
+        <Button onClick={() => {
+          openFile('csv', setCsvText)
+        }}>csv開く</Button>
+        <Button onClick={() => {
+          openFile('html', setHtmlText)
+        }}>html開く</Button>
+
         <Button>csvコピー</Button>
         <Button>htmlコピー</Button>
       </div>

--- a/wordlist/frontend/src/App.tsx
+++ b/wordlist/frontend/src/App.tsx
@@ -1,12 +1,13 @@
 import { useState } from "react";
-import { GenerateTable, GenerateCsv, Save, Open } from "../wailsjs/go/main/App";
+import { GenerateTable, GenerateCsv, Save, Open, SaveAs } from "../wailsjs/go/main/App";
 import { Button, TextField } from "@mui/material";
 import styles from "./App.module.css";
 
 function App() {
   const [csvText, setCsvText] = useState("");
   const [htmlText, setHtmlText] = useState("");
-  const [fileName, setFileName] = useState("");
+  const [csvFilePath, setCsvFilePath] = useState("");
+  const [htmlFilePath, setHtmlFilePath] = useState("");
   const generateHtml = () => {
     GenerateTable(csvText).then((res) => setHtmlText(res));
   };
@@ -15,46 +16,74 @@ function App() {
     GenerateCsv(htmlText).then((res) => setCsvText(res));
   };
 
-  const saveFile = (content: string, ext: string) => {
-    Save(content, ext);
+  const saveCsv = () => {
+    Save(csvText, 'csv').then((res) => setCsvFilePath(res));
   }
 
-  const openFile = (ext: string, setState: (s: string) => void) => {
-    Open(ext).then((res) => setState(res));
+  const saveHtml = () => {
+    Save(htmlText, 'html').then((res) => setHtmlFilePath(res));
+  }
+
+  const openCsv = () => {
+    Open('csv')
+      .then((res) => {
+        setCsvText(res[0]);
+        setCsvFilePath(res[1]);
+      });
+  }
+  const openHtml = () => {
+    Open('html')
+      .then((res) => {
+        setHtmlText(res[0]);
+        setHtmlFilePath(res[1]);
+      });
+  }
+
+
+  const resave = (content: string, path: string) => {
+    if (path === "") {
+      return;
+    }
+    SaveAs(content, path);
   }
 
   return (
     <div className={styles.main}>
       <div className={styles.titleArea}>
         <Button
-          onClick={() => {
-            saveFile(csvText, 'csv')
-          }}
+          onClick={() => saveCsv()}
           variant="contained"
         >
           csv保存
         </Button>
         <Button
-          onClick={() => {
-            saveFile(csvText, 'html')
-          }}
+          onClick={() => saveHtml()}
           variant="contained"
         >
           html保存
         </Button>
 
         <Button
-          onClick={() => {
-            openFile('csv', setCsvText)
-          }}
+          onClick={() => resave(csvText, csvFilePath)}
+          variant="contained"
+        >
+          csv上書き保存
+        </Button>
+        <Button
+          onClick={() => resave(htmlText, htmlFilePath)}
+          variant="contained"
+        >
+          html上書き保存
+        </Button>
+
+        <Button
+          onClick={() => openCsv()}
           variant="contained"
         >
           csv開く
         </Button>
         <Button
-          onClick={() => {
-            openFile('html', setHtmlText)
-          }}
+          onClick={() => openHtml()}
           variant="contained"
         >
           html開く

--- a/wordlist/frontend/src/App.tsx
+++ b/wordlist/frontend/src/App.tsx
@@ -23,69 +23,49 @@ function App() {
     Open(ext).then((res) => setState(res));
   }
 
-  // ファイル読み込みボタン
-  const FolderSelector = () => {
-    const handleFolderSelect = (event: any) => {
-      const file = event.target.files[0];
-      const reader = new FileReader();
-      reader.onload = () => {
-        if (reader.result) {
-          const filename = file.name;
-          const ext = filename.split('.').pop();
-          const content = reader.result?.toString()
-          setFileName(filename);
-          if (ext == 'csv') {
-            setCsvText(content)
-          } else if (ext == 'html') {
-            setHtmlText(content)
-          } else {
-            // TODO: トーストを出す
-          }
-        }
-      }
-      reader.readAsText(file);
-    };
-
-    return (
-      <span>
-        <input
-          type="file"
-          style={{ display: "none" }}
-          onChange={handleFolderSelect}
-          id="folder-input"
-          accept='.csv, .html'
-        />
-        <label htmlFor="folder-input">
-          <Button variant="contained" component="span">
-            フォルダを選択
-          </Button>
-        </label>
-      </span>
-    );
-  };
-
   return (
     <div className={styles.main}>
       <div className={styles.titleArea}>
-        <FolderSelector />
-        <span style={{ color: "black" }}> filename: {fileName}</span>
+        <Button
+          onClick={() => {
+            saveFile(csvText, 'csv')
+          }}
+          variant="contained"
+        >
+          csv保存
+        </Button>
+        <Button
+          onClick={() => {
+            saveFile(csvText, 'html')
+          }}
+          variant="contained"
+        >
+          html保存
+        </Button>
 
-        <Button onClick={() => {
-          saveFile(csvText, 'csv')
-        }}>csv保存</Button>
-        <Button onClick={() => {
-          saveFile(csvText, 'html')
-        }}>html保存</Button>
+        <Button
+          onClick={() => {
+            openFile('csv', setCsvText)
+          }}
+          variant="contained"
+        >
+          csv開く
+        </Button>
+        <Button
+          onClick={() => {
+            openFile('html', setHtmlText)
+          }}
+          variant="contained"
+        >
+          html開く
+        </Button>
 
-        <Button onClick={() => {
-          openFile('csv', setCsvText)
-        }}>csv開く</Button>
-        <Button onClick={() => {
-          openFile('html', setHtmlText)
-        }}>html開く</Button>
-
-        <Button>csvコピー</Button>
-        <Button>htmlコピー</Button>
+        <Button variant="contained">
+          csvコピー
+        </Button>
+        <Button variant="contained">
+          htmlコピー
+        </Button>
       </div>
       <div className={styles.contentArea}>
         <div className={styles.csvArea}>

--- a/wordlist/frontend/wailsjs/go/main/App.d.ts
+++ b/wordlist/frontend/wailsjs/go/main/App.d.ts
@@ -6,3 +6,7 @@ export function GenerateCsv(arg1:string):Promise<string>;
 export function GenerateTable(arg1:string):Promise<string>;
 
 export function Greet(arg1:string):Promise<string>;
+
+export function Open(arg1:string):Promise<string>;
+
+export function Save(arg1:string,arg2:string):Promise<void>;

--- a/wordlist/frontend/wailsjs/go/main/App.d.ts
+++ b/wordlist/frontend/wailsjs/go/main/App.d.ts
@@ -7,6 +7,8 @@ export function GenerateTable(arg1:string):Promise<string>;
 
 export function Greet(arg1:string):Promise<string>;
 
-export function Open(arg1:string):Promise<string>;
+export function Open(arg1:string):Promise<Array<string>>;
 
-export function Save(arg1:string,arg2:string):Promise<void>;
+export function Save(arg1:string,arg2:string):Promise<string>;
+
+export function SaveAs(arg1:string,arg2:string):Promise<void>;

--- a/wordlist/frontend/wailsjs/go/main/App.js
+++ b/wordlist/frontend/wailsjs/go/main/App.js
@@ -13,3 +13,11 @@ export function GenerateTable(arg1) {
 export function Greet(arg1) {
   return window['go']['main']['App']['Greet'](arg1);
 }
+
+export function Open(arg1) {
+  return window['go']['main']['App']['Open'](arg1);
+}
+
+export function Save(arg1, arg2) {
+  return window['go']['main']['App']['Save'](arg1, arg2);
+}

--- a/wordlist/frontend/wailsjs/go/main/App.js
+++ b/wordlist/frontend/wailsjs/go/main/App.js
@@ -21,3 +21,7 @@ export function Open(arg1) {
 export function Save(arg1, arg2) {
   return window['go']['main']['App']['Save'](arg1, arg2);
 }
+
+export function SaveAs(arg1, arg2) {
+  return window['go']['main']['App']['SaveAs'](arg1, arg2);
+}


### PR DESCRIPTION
## 🔖 チケットへのリンク

- #6 
- #19
-  #21

## ✨ やったこと

- フロント完結のファイルを開く機能を廃止
- システムダイアログを使用してファイルを開けるようにした
- システムダイアログを使用してファイルを保存できるようにした
- ファイルを上書き保存できるようにした
- コードコピー用の仮ボタンを配置した

## 🔥 やらないこと

- UIの調整

## 🙆 できるようになること（ユーザ目線）

- ファイルを保存できるようになった
- ファイルを上書き保存できるようになった

## 🙅 できなくなること（ユーザ目線）

- 無し

## 🚀 動作確認

- GUIでファイルを開く・保存・上書き保存できることを確認

## 👽️ その他

- 無し