### PR TITLE
Fix/backend/translating error

### DIFF
--- a/wordlist/parse/parsecsv.go
+++ b/wordlist/parse/parsecsv.go
@@ -44,6 +44,9 @@ func createWord(line string) (Word, error) {
 	if len(splited) == 2 || strings.TrimSpace(meaning) == "" {
 		meaning = scraping.FetchWordMeaning(name)
 		meaning = strings.TrimSpace(meaning)
+		if meaning == "" {
+			meaning = "none"
+		}
 	}
 
 	return Word{

--- a/wordlist/parse/parsecsv.go
+++ b/wordlist/parse/parsecsv.go
@@ -8,7 +8,9 @@ import (
 )
 
 func ParseCsv(csv string) ([]Word, error) {
+	csv = deleteBlankLIne(csv)
 	lines := strings.Split(csv, "\n")
+
 	res := make([]Word, len(lines))
 	for i, line := range lines {
 		word, err := createWord(line)
@@ -18,6 +20,17 @@ func ParseCsv(csv string) ([]Word, error) {
 		res[i] = word
 	}
 	return res, nil
+}
+
+func deleteBlankLIne(str string) string {
+	split := strings.Split(str, "\n")
+	var newSplit []string
+	for _, s := range split {
+		if s != "" {
+			newSplit = append(newSplit, s)
+		}
+	}
+	return strings.Join(newSplit, "\n")
 }
 
 func createWord(line string) (Word, error) {


### PR DESCRIPTION
## 🔖 チケットへのリンク

- #24 

## ✨ やったこと

- 翻訳APIの戻り値が空文字のときは"none"と扱うようにした
- 空行を無視するようにした

## 🔥 やらないこと

- 無し

## 🙆 できるようになること（ユーザ目線）

- 翻訳失敗を確認できるようになる
- 空行を処理せずに変換できるようになる

## 🙅 できなくなること（ユーザ目線）

- 無し

## 🚀 動作確認

- go testで確認
- GUIで空行が無視されることを確認

## 👽️ その他

- 無し
