### PR TITLE
Feat/frontend/header button

### DIFF
--- a/wordlist/frontend/src/App.module.css
+++ b/wordlist/frontend/src/App.module.css
@@ -1,5 +1,11 @@
+:root {
+  --main-bg-color: rgb(211, 236, 231);
+  --button-bg-color: rgb(156, 235, 219);
+  --button-hover-bg-color: rgb(0, 146, 117);
+}
 .main {
   height: 100vh;
+  background-color: var(--main-bg-color);
 }
 
 .contentArea {

--- a/wordlist/frontend/src/App.tsx
+++ b/wordlist/frontend/src/App.tsx
@@ -1,13 +1,12 @@
 import { useState } from "react";
-import { GenerateTable, GenerateCsv, Save, Open, SaveAs } from "../wailsjs/go/main/App";
+import { GenerateTable, GenerateCsv } from "../wailsjs/go/main/App";
 import { Button, TextField } from "@mui/material";
 import styles from "./App.module.css";
+import { HeaderButton } from "./component/HeaderButton";
 
 function App() {
   const [csvText, setCsvText] = useState("");
   const [htmlText, setHtmlText] = useState("");
-  const [csvFilePath, setCsvFilePath] = useState("");
-  const [htmlFilePath, setHtmlFilePath] = useState("");
   const generateHtml = () => {
     GenerateTable(csvText).then((res) => setHtmlText(res));
   };
@@ -16,104 +15,15 @@ function App() {
     GenerateCsv(htmlText).then((res) => setCsvText(res));
   };
 
-  const saveCsv = () => {
-    Save(csvText, 'csv').then((res) => setCsvFilePath(res));
-  }
-
-  const saveHtml = () => {
-    Save(htmlText, 'html').then((res) => setHtmlFilePath(res));
-  }
-
-  const openCsv = () => {
-    Open('csv')
-      .then((res) => {
-        setCsvText(res[0]);
-        setCsvFilePath(res[1]);
-      });
-  }
-  const openHtml = () => {
-    Open('html')
-      .then((res) => {
-        setHtmlText(res[0]);
-        setHtmlFilePath(res[1]);
-      });
-  }
-
-
-  const resave = (content: string, path: string) => {
-    if (path === "") {
-      return;
-    }
-    SaveAs(content, path);
-  }
-
   return (
     <div className={styles.main}>
-      <div className={styles.titleArea}>
-        <Button
-          onClick={() => saveCsv()}
-          variant="contained"
-        >
-          csv保存
-        </Button>
-        <Button
-          onClick={() => saveHtml()}
-          variant="contained"
-        >
-          html保存
-        </Button>
-
-        <Button
-          onClick={() => resave(csvText, csvFilePath)}
-          variant="contained"
-        >
-          csv上書き保存
-        </Button>
-        <Button
-          onClick={() => resave(htmlText, htmlFilePath)}
-          variant="contained"
-        >
-          html上書き保存
-        </Button>
-
-        <Button
-          onClick={() => openCsv()}
-          variant="contained"
-        >
-          csv開く
-        </Button>
-        <Button
-          onClick={() => openHtml()}
-          variant="contained"
-        >
-          html開く
-        </Button>
-
-        <Button variant="contained">
-          csvコピー
-        </Button>
-        <Button variant="contained">
-          htmlコピー
-        </Button>
-      </div>
+      <HeaderButton csvText={csvText} setCsvText={setCsvText} htmlText={htmlText} setHtmlText={setHtmlText} />
       <div className={styles.contentArea}>
         <div className={styles.csvArea}>
-          <TextField
-            label="Multiline"
-            multiline
-            fullWidth
-            value={csvText}
-            onChange={(e) => setCsvText(e.target.value)}
-          />
+          <TextField label="Multiline" multiline fullWidth value={csvText} onChange={(e) => setCsvText(e.target.value)} />
         </div>
         <div className={styles.htmlArea}>
-          <TextField
-            label="Multiline"
-            multiline
-            value={htmlText}
-            fullWidth
-            onChange={(e) => setHtmlText(e.target.value)}
-          />
+          <TextField label="Multiline" multiline value={htmlText} fullWidth onChange={(e) => setHtmlText(e.target.value)} />
         </div>
         <div className={styles.csvToHtmlButtonArea}>
           <Button onClick={generateHtml} variant="contained">

--- a/wordlist/frontend/src/App.tsx
+++ b/wordlist/frontend/src/App.tsx
@@ -1,12 +1,15 @@
 import { useState } from "react";
 import { GenerateTable, GenerateCsv } from "../wailsjs/go/main/App";
-import { Button, TextField } from "@mui/material";
+import { Button, IconButton, TextField, Tooltip } from "@mui/material";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import styles from "./App.module.css";
 import { HeaderButton } from "./component/HeaderButton";
 
 function App() {
   const [csvText, setCsvText] = useState("");
   const [htmlText, setHtmlText] = useState("");
+  const [tooltipTitle, setTooltipTitle] = useState("Copy to Clipboard");
+
   const generateHtml = () => {
     GenerateTable(csvText).then((res) => setHtmlText(res));
   };
@@ -15,15 +18,31 @@ function App() {
     GenerateCsv(htmlText).then((res) => setCsvText(res));
   };
 
+  const copyToClipboard = async (text: string) => {
+    await navigator.clipboard.writeText(text);
+    setTooltipTitle("Copied!");
+  };
+
   return (
     <div className={styles.main}>
       <HeaderButton csvText={csvText} setCsvText={setCsvText} htmlText={htmlText} setHtmlText={setHtmlText} />
       <div className={styles.contentArea}>
         <div className={styles.csvArea}>
-          <TextField label="Multiline" multiline fullWidth value={csvText} onChange={(e) => setCsvText(e.target.value)} />
+          <Tooltip title={tooltipTitle} placement="top" arrow>
+            <IconButton color="primary" size="small" onClick={() => copyToClipboard(csvText)} onMouseLeave={() => setTooltipTitle("Copy to Clipboard")}>
+              <ContentCopyIcon />
+            </IconButton>
+          </Tooltip>
+          <TextField label="csv" multiline fullWidth value={csvText} onChange={(e) => setCsvText(e.target.value)} />
         </div>
         <div className={styles.htmlArea}>
-          <TextField label="Multiline" multiline value={htmlText} fullWidth onChange={(e) => setHtmlText(e.target.value)} />
+          <Tooltip title={tooltipTitle} placement="top" arrow>
+            <IconButton color="primary" size="small" onClick={() => copyToClipboard(htmlText)} onMouseLeave={() => setTooltipTitle("Copy to Clipboard")}>
+              <ContentCopyIcon />
+            </IconButton>
+          </Tooltip>
+
+          <TextField label="html" multiline value={htmlText} fullWidth onChange={(e) => setHtmlText(e.target.value)} />
         </div>
         <div className={styles.csvToHtmlButtonArea}>
           <Button onClick={generateHtml} variant="contained">

--- a/wordlist/frontend/src/component/HeaderButton.module.css
+++ b/wordlist/frontend/src/component/HeaderButton.module.css
@@ -1,0 +1,26 @@
+.header {
+  padding: 20px 5%;
+  width: 100%;
+  height: 10vh;
+  box-sizing: border-box;
+  display: flex;
+  justify-content: space-between;
+}
+
+.header__button{
+  width: 40%;
+  display: flex;
+  justify-content: space-between;
+}
+
+.header__button Button {
+  width: fit-content;
+  color: #000;
+  background: var(--button-bg-color);
+  border: none;
+}
+
+.header__button Button:hover {
+  color: #fff;
+  background: var(--button-hover-bg-color);
+}

--- a/wordlist/frontend/src/component/HeaderButton.tsx
+++ b/wordlist/frontend/src/component/HeaderButton.tsx
@@ -11,7 +11,7 @@ type HeaderButtonProps = {
   setHtmlText: (text: string) => void;
 };
 
-export const HeaderButton: React.FC<HeaderButtonProps> = ({ csvText, htmlText, setCsvText, setHtmlText }) => {
+export const HeaderButton = ({ csvText, htmlText, setCsvText, setHtmlText }: HeaderButtonProps) => {
   const [csvFilePath, setCsvFilePath] = useState("");
   const [htmlFilePath, setHtmlFilePath] = useState("");
 

--- a/wordlist/frontend/src/component/HeaderButton.tsx
+++ b/wordlist/frontend/src/component/HeaderButton.tsx
@@ -64,9 +64,6 @@ export const HeaderButton: React.FC<HeaderButtonProps> = ({ csvText, htmlText, s
       <Button onClick={() => openHtml()} variant="contained">
         html開く
       </Button>
-
-      <Button variant="contained">csvコピー</Button>
-      <Button variant="contained">htmlコピー</Button>
     </div>
   );
 };

--- a/wordlist/frontend/src/component/HeaderButton.tsx
+++ b/wordlist/frontend/src/component/HeaderButton.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import React from "react";
+import { Save, Open, SaveAs } from "../../wailsjs/go/main/App";
+import { Button } from "@mui/material";
+
+type HeaderButtonProps = {
+  csvText: string;
+  setCsvText: (text: string) => void;
+  htmlText: string;
+  setHtmlText: (text: string) => void;
+};
+
+export const HeaderButton: React.FC<HeaderButtonProps> = ({ csvText, htmlText, setCsvText, setHtmlText }) => {
+  const [csvFilePath, setCsvFilePath] = useState("");
+  const [htmlFilePath, setHtmlFilePath] = useState("");
+
+  const saveCsv = () => {
+    Save(csvText, "csv").then((res) => setCsvFilePath(res));
+  };
+
+  const saveHtml = () => {
+    Save(htmlText, "html").then((res) => setHtmlFilePath(res));
+  };
+
+  const openCsv = () => {
+    Open("csv").then((res) => {
+      setCsvText(res[0]);
+      setCsvFilePath(res[1]);
+    });
+  };
+  const openHtml = () => {
+    Open("html").then((res) => {
+      setHtmlText(res[0]);
+      setHtmlFilePath(res[1]);
+    });
+  };
+
+  const resave = (content: string, path: string) => {
+    if (path === "") {
+      return;
+    }
+    SaveAs(content, path);
+  };
+
+  return (
+    <div>
+      <Button onClick={() => saveCsv()} variant="contained">
+        csv保存
+      </Button>
+      <Button onClick={() => saveHtml()} variant="contained">
+        html保存
+      </Button>
+
+      <Button onClick={() => resave(csvText, csvFilePath)} variant="contained">
+        csv上書き保存
+      </Button>
+      <Button onClick={() => resave(htmlText, htmlFilePath)} variant="contained">
+        html上書き保存
+      </Button>
+
+      <Button onClick={() => openCsv()} variant="contained">
+        csv開く
+      </Button>
+      <Button onClick={() => openHtml()} variant="contained">
+        html開く
+      </Button>
+
+      <Button variant="contained">csvコピー</Button>
+      <Button variant="contained">htmlコピー</Button>
+    </div>
+  );
+};

--- a/wordlist/frontend/src/component/HeaderButton.tsx
+++ b/wordlist/frontend/src/component/HeaderButton.tsx
@@ -36,9 +36,16 @@ export const HeaderButton: React.FC<HeaderButtonProps> = ({ csvText, htmlText, s
     });
   };
 
-  const resave = (content: string, path: string) => {
+  const resave = (content: string, path: string, type: string) => {
     if (path === "") {
-      return;
+      switch (type) {
+        case "csv":
+          saveCsv();
+          return;
+        case "html":
+          saveHtml();
+          return;
+      }
     }
     SaveAs(content, path);
   };
@@ -49,7 +56,7 @@ export const HeaderButton: React.FC<HeaderButtonProps> = ({ csvText, htmlText, s
         <Button onClick={() => saveCsv()} variant="contained">
           csv保存
         </Button>
-        <Button onClick={() => resave(csvText, csvFilePath)} variant="contained">
+        <Button onClick={() => resave(csvText, csvFilePath, "csv")} variant="contained">
           csv上書き保存
         </Button>
         <Button onClick={() => openCsv()} variant="contained">
@@ -60,7 +67,7 @@ export const HeaderButton: React.FC<HeaderButtonProps> = ({ csvText, htmlText, s
         <Button onClick={() => saveHtml()} variant="contained">
           html保存
         </Button>
-        <Button onClick={() => resave(htmlText, htmlFilePath)} variant="contained">
+        <Button onClick={() => resave(htmlText, htmlFilePath, "html")} variant="contained">
           html上書き保存
         </Button>
         <Button onClick={() => openHtml()} variant="contained">

--- a/wordlist/frontend/src/component/HeaderButton.tsx
+++ b/wordlist/frontend/src/component/HeaderButton.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import React from "react";
 import { Save, Open, SaveAs } from "../../wailsjs/go/main/App";
 import { Button } from "@mui/material";
+import styles from "./HeaderButton.module.css";
 
 type HeaderButtonProps = {
   csvText: string;
@@ -43,27 +44,29 @@ export const HeaderButton: React.FC<HeaderButtonProps> = ({ csvText, htmlText, s
   };
 
   return (
-    <div>
-      <Button onClick={() => saveCsv()} variant="contained">
-        csv保存
-      </Button>
-      <Button onClick={() => saveHtml()} variant="contained">
-        html保存
-      </Button>
-
-      <Button onClick={() => resave(csvText, csvFilePath)} variant="contained">
-        csv上書き保存
-      </Button>
-      <Button onClick={() => resave(htmlText, htmlFilePath)} variant="contained">
-        html上書き保存
-      </Button>
-
-      <Button onClick={() => openCsv()} variant="contained">
-        csv開く
-      </Button>
-      <Button onClick={() => openHtml()} variant="contained">
-        html開く
-      </Button>
+    <div className={styles.header}>
+      <div className={styles.header__button}>
+        <Button onClick={() => saveCsv()} variant="contained">
+          csv保存
+        </Button>
+        <Button onClick={() => resave(csvText, csvFilePath)} variant="contained">
+          csv上書き保存
+        </Button>
+        <Button onClick={() => openCsv()} variant="contained">
+          csv開く
+        </Button>
+      </div>
+      <div className={styles.header__button}>
+        <Button onClick={() => saveHtml()} variant="contained">
+          html保存
+        </Button>
+        <Button onClick={() => resave(htmlText, htmlFilePath)} variant="contained">
+          html上書き保存
+        </Button>
+        <Button onClick={() => openHtml()} variant="contained">
+          html開く
+        </Button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## 🔖 チケットへのリンク

- #7 

## ✨ やったこと

- 保存，上書き保存，開く，コピーボタンのスタイルの変更と機能の追加を行った．

## 🔥 やらないこと

- コピーボタンのスタイルに関する作業は別ブランチにて行う．
- テキストエリア帳部分のUI変更．

## 🙆 できるようになること（ユーザ目線）

- コピーボタンを押下するとテキストエリアの内容がクリップボードにコピーされる
- ファイルを開いたり保存していない状態で上書き保存ボタンを押したとき，通常の保存を行うことができる

## 🙅 できなくなること（ユーザ目線）

- なし

## 🚀 動作確認

- wails devで動作確認済み

## 👽️ その他

- 
